### PR TITLE
Added Fullscreen control

### DIFF
--- a/config/tailwind/dropdown.js
+++ b/config/tailwind/dropdown.js
@@ -3,7 +3,7 @@ const plugin = require('tailwindcss/plugin')
 module.exports = plugin(({ addComponents }) => {
   const dropdown = {
     '.dropdown': {
-      '@apply inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl':
+      '@apply inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50':
         {},
 
       // handle dropdown animation

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -121,7 +121,7 @@ export function App(props: AppProps) {
       className={cx(
         'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all',
         {
-          '!grid-cols-[0px,1fr]': !utilityStore.isUtilityBarVisible,
+          '!grid-cols-[0px,1fr]': !utilityStore.isNavBarVisible,
         },
       )}
     >
@@ -136,7 +136,7 @@ export function App(props: AppProps) {
       <div className="relative z-10 flex flex-col bg-white">
         <UtilityBar showSettings={!hasConfigUrl} />
 
-        <div className="flex items-stretch justify-center flex-grow">
+        <div className="flex flex-grow items-stretch justify-center">
           {!hasConfigUrl && isWelcomeVisible ? (
             <Welcome />
           ) : (

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -117,7 +117,14 @@ export function App(props: AppProps) {
   }
 
   return (
-    <div className="grid h-screen grid-cols-[250px,_1fr] bg-gray-100">
+    <div
+      className={cx(
+        'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all',
+        {
+          '!grid-cols-[0px,1fr]': !utilityStore.isUtilityBarVisible,
+        },
+      )}
+    >
       {activeNavItem !== undefined ? (
         <Nav
           activeNavItem={activeNavItem}
@@ -126,10 +133,10 @@ export function App(props: AppProps) {
         />
       ) : null}
 
-      <div className="flex flex-col bg-white">
+      <div className="relative z-10 flex flex-col bg-white">
         <UtilityBar showSettings={!hasConfigUrl} />
 
-        <div className="flex flex-grow items-stretch justify-center">
+        <div className="flex items-stretch justify-center flex-grow">
           {!hasConfigUrl && isWelcomeVisible ? (
             <Welcome />
           ) : (

--- a/src/components/ToggleFullscreen.tsx
+++ b/src/components/ToggleFullscreen.tsx
@@ -8,7 +8,10 @@ export default function () {
   // Toggle nav bar visibility with the `f` key and exit fullscreen with the `Escape` key
   const keydownHandler = (e: KeyboardEvent) => {
     // Don't toggle nav bar visibility if the user is typing in an input
-    if (document.activeElement instanceof HTMLInputElement) {
+    if (
+      document.activeElement instanceof HTMLInputElement ||
+      document.activeElement instanceof HTMLTextAreaElement
+    ) {
       return
     }
 

--- a/src/components/ToggleFullscreen.tsx
+++ b/src/components/ToggleFullscreen.tsx
@@ -5,21 +5,19 @@ import { useUtilityBarStore } from '../features/utility-bar/store'
 export default function () {
   const utilityStore = useUtilityBarStore()
 
-  // Toggle utility bar visibility with the `f` key and exit fullscreen with the `Escape` key
+  // Toggle nav bar visibility with the `f` key and exit fullscreen with the `Escape` key
   const keydownHandler = (e: KeyboardEvent) => {
-    // Don't toggle utility bar visibility if the user is typing in an input
+    // Don't toggle nav bar visibility if the user is typing in an input
     if (document.activeElement instanceof HTMLInputElement) {
       return
     }
 
     switch (e.key) {
       case 'f':
-        return utilityStore.setIsUtilityBarVisible(
-          !utilityStore.isUtilityBarVisible,
-        )
+        return utilityStore.setIsNavBarVisible(!utilityStore.isNavBarVisible)
 
       case 'Escape':
-        return utilityStore.setIsUtilityBarVisible(true)
+        return utilityStore.setIsNavBarVisible(true)
 
       default:
         return
@@ -31,21 +29,21 @@ export default function () {
     return () => {
       document.removeEventListener('keydown', keydownHandler)
     }
-  }, [utilityStore.isUtilityBarVisible])
+  }, [utilityStore.isNavBarVisible])
 
   return (
     <button
       className="btn-subtle btn-icon"
       title={
-        utilityStore.isUtilityBarVisible
+        utilityStore.isNavBarVisible
           ? 'Go Fullscreen [F]'
           : 'Exit Fullscreen [F]'
       }
       onClick={() =>
-        utilityStore.setIsUtilityBarVisible(!utilityStore.isUtilityBarVisible)
+        utilityStore.setIsNavBarVisible(!utilityStore.isNavBarVisible)
       }
     >
-      {utilityStore.isUtilityBarVisible ? (
+      {utilityStore.isNavBarVisible ? (
         <EnterFullScreenIcon />
       ) : (
         <CrossCircledIcon />

--- a/src/components/ToggleFullscreen.tsx
+++ b/src/components/ToggleFullscreen.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'preact/hooks'
+import { CrossCircledIcon, EnterFullScreenIcon } from '@radix-ui/react-icons'
+import { useUtilityBarStore } from '../features/utility-bar/store'
+
+export default function () {
+  const utilityStore = useUtilityBarStore()
+
+  // Toggle utility bar visibility with the `f` key and exit fullscreen with the `Escape` key
+  const keydownHandler = (e: KeyboardEvent) => {
+    // Don't toggle utility bar visibility if the user is typing in an input
+    if (document.activeElement instanceof HTMLInputElement) {
+      return
+    }
+
+    switch (e.key) {
+      case 'f':
+        return utilityStore.setIsUtilityBarVisible(
+          !utilityStore.isUtilityBarVisible,
+        )
+
+      case 'Escape':
+        return utilityStore.setIsUtilityBarVisible(true)
+
+      default:
+        return
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('keydown', keydownHandler)
+    return () => {
+      document.removeEventListener('keydown', keydownHandler)
+    }
+  }, [utilityStore.isUtilityBarVisible])
+
+  return (
+    <button
+      className="btn-subtle btn-icon"
+      title={
+        utilityStore.isUtilityBarVisible
+          ? 'Go Fullscreen [F]'
+          : 'Exit Fullscreen [F]'
+      }
+      onClick={() =>
+        utilityStore.setIsUtilityBarVisible(!utilityStore.isUtilityBarVisible)
+      }
+    >
+      {utilityStore.isUtilityBarVisible ? (
+        <EnterFullScreenIcon />
+      ) : (
+        <CrossCircledIcon />
+      )}
+    </button>
+  )
+}

--- a/src/features/nav/Nav.tsx
+++ b/src/features/nav/Nav.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'preact/hooks'
+import cx from 'classnames'
 import { NavItem } from '../../components/NavItem'
 import { Search } from '../../components/Search'
+import { useUtilityBarStore } from '../utility-bar/store'
 
 export interface NavItemInterface {
   title: string
@@ -25,8 +27,17 @@ export function Nav(props: NavProps) {
     )
   })
 
+  const utilityStore = useUtilityBarStore()
+
   return (
-    <nav className="bg-gray-100 bg-gradient-to-l from-gray-400/30 to-transparent to-35% py-8 gap-8 flex flex-col">
+    <nav
+      className={cx(
+        'flex min-w-[250px] flex-col gap-8 overflow-hidden bg-gray-100 bg-gradient-to-l from-gray-400/30 to-transparent to-35% py-8 transition-all',
+        {
+          'invisible opacity-0': !utilityStore.isUtilityBarVisible,
+        },
+      )}
+    >
       <div className="px-6">
         <Search onInput={(e) => setCurrentSearch(e.currentTarget.value)} />
       </div>

--- a/src/features/nav/Nav.tsx
+++ b/src/features/nav/Nav.tsx
@@ -34,7 +34,7 @@ export function Nav(props: NavProps) {
       className={cx(
         'flex min-w-[250px] flex-col gap-8 overflow-hidden bg-gray-100 bg-gradient-to-l from-gray-400/30 to-transparent to-35% py-8 transition-all',
         {
-          'invisible opacity-0': !utilityStore.isUtilityBarVisible,
+          'invisible opacity-0': !utilityStore.isNavBarVisible,
         },
       )}
     >

--- a/src/features/utility-bar/UtilityBar.tsx
+++ b/src/features/utility-bar/UtilityBar.tsx
@@ -4,10 +4,10 @@ import { Dropdown } from '../../components/Dropdown'
 import {
   AspectRatioIcon,
   BlendingModeIcon,
-  EnterFullScreenIcon,
   GearIcon,
 } from '@radix-ui/react-icons'
 import { Dialog } from '../../components/Dialog'
+import ToggleFullscreen from '../../components/ToggleFullscreen'
 
 interface UtilityBarProps {
   showSettings: boolean
@@ -18,7 +18,7 @@ export default function (props: UtilityBarProps) {
 
   return (
     <div>
-      <header className="flex h-10 justify-between gap-4 border-l border-white bg-gray-100 px-4">
+      <header className="flex justify-between h-10 gap-4 px-4 bg-gray-100 border-l border-white">
         <div className="flex items-center gap-2">
           {/* Theme Control */}
           <button className="btn-subtle btn-icon" title="Theme">
@@ -71,9 +71,7 @@ export default function (props: UtilityBarProps) {
           )}
 
           {/* Fullscreen control */}
-          <button className="btn-subtle btn-icon" title="Fullscreen">
-            <EnterFullScreenIcon />
-          </button>
+          <ToggleFullscreen />
         </div>
       </header>
     </div>

--- a/src/features/utility-bar/store.ts
+++ b/src/features/utility-bar/store.ts
@@ -6,8 +6,8 @@ interface UtilityState {
   setIsSettingsVisible: (newVal: boolean) => void
   activeScreenSize: ScreenSize
   setActiveScreenSize: (newVal: ScreenSize) => void
-  isUtilityBarVisible: boolean
-  setIsUtilityBarVisible: (visible: boolean) => void
+  isNavBarVisible: boolean
+  setIsNavBarVisible: (visible: boolean) => void
 }
 
 export enum ScreenSize {
@@ -45,8 +45,8 @@ export const useUtilityBarStore = create<UtilityState>()(
     activeScreenSize: ScreenSize.Desktop,
     setActiveScreenSize: (val: ScreenSize) =>
       set(() => ({ activeScreenSize: val })),
-    isUtilityBarVisible: true,
-    setIsUtilityBarVisible: (visible: boolean) =>
-      set(() => ({ isUtilityBarVisible: visible })),
+    isNavBarVisible: true,
+    setIsNavBarVisible: (visible: boolean) =>
+      set(() => ({ isNavBarVisible: visible })),
   })),
 )

--- a/src/features/utility-bar/store.ts
+++ b/src/features/utility-bar/store.ts
@@ -6,7 +6,10 @@ interface UtilityState {
   setIsSettingsVisible: (newVal: boolean) => void
   activeScreenSize: ScreenSize
   setActiveScreenSize: (newVal: ScreenSize) => void
+  isUtilityBarVisible: boolean
+  setIsUtilityBarVisible: (visible: boolean) => void
 }
+
 export enum ScreenSize {
   Mobile,
   Tablet,
@@ -42,5 +45,8 @@ export const useUtilityBarStore = create<UtilityState>()(
     activeScreenSize: ScreenSize.Desktop,
     setActiveScreenSize: (val: ScreenSize) =>
       set(() => ({ activeScreenSize: val })),
+    isUtilityBarVisible: true,
+    setIsUtilityBarVisible: (visible: boolean) =>
+      set(() => ({ isUtilityBarVisible: visible })),
   })),
 )


### PR DESCRIPTION
## Issue

- #9 

## About
This PR introduces a toggleable fullscreen control for displaying and hiding the side nav bar. By default, pressing the `F` key will toggle the sidebar visible and hidden. When the sidebar is hidden, `esc` can be pressed to reset the view as well. 

I made sure to also test whether or not this would have any impact on user inputs. When typing inside of an input, the key event listener is ignored so as to not toggle the view. Lastly, I also remove the visibility of the sidebar so that we have no focus within that area while it's collapsed.

## Preview
![fs](https://github.com/vigetlabs/parts-kit/assets/8878152/412854e9-8c98-4196-bebe-5e8e76b1d5fc)
