### PR TITLE
Moved shortcuts to own file and added viewport hotkey

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,7 +18,7 @@ import {
   UseHistory,
   SEARCH_PARAM_PART,
 } from './features/nav/routing.ts'
-import { uniqueId } from './utilities/string.ts'
+import KeyboardShortcuts from './components/KeyboardShortcuts.tsx'
 
 export interface AppProps {
   configUrl: string | null
@@ -116,6 +116,8 @@ export function App(props: AppProps) {
     useHistory.push(url, { url: foundItem.url })
   }
 
+  KeyboardShortcuts()
+
   return (
     <div
       className={cx(
@@ -136,7 +138,7 @@ export function App(props: AppProps) {
       <div className="relative z-10 flex flex-col bg-white">
         <UtilityBar showSettings={!hasConfigUrl} />
 
-        <div className="flex flex-grow items-stretch justify-center">
+        <div className="flex items-stretch justify-center flex-grow">
           {!hasConfigUrl && isWelcomeVisible ? (
             <Welcome />
           ) : (
@@ -148,7 +150,7 @@ export function App(props: AppProps) {
             >
               {/* Changing the src of iframes will muck up your history. Using key to rerender when the nav changes is a workaround */}
               <iframe
-                key={activeNavItem?.url + uniqueId()}
+                key={activeNavItem?.url}
                 className={cx('h-full w-full', {
                   'rounded border-2 border-gray-100':
                     utilityStore.activeScreenSize !== ScreenSize.Desktop,

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -7,6 +7,8 @@ interface RootProps {
   align?: 'start' | 'center' | 'end'
   side?: 'top' | 'right' | 'bottom' | 'left'
   hasArrow?: boolean
+  open?: boolean
+  onOpenChange?: () => void
 }
 
 const Root = (props: RootProps) => {

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'preact/hooks'
+import { useUtilityBarStore } from '../features/utility-bar/store'
+
+export default function () {
+  const utilityStore = useUtilityBarStore()
+
+  // handles different keyboard shortcuts
+  const keydownHandler = (e: KeyboardEvent) => {
+    // don't assess shortcuts when inside of an input or textarea
+    if (
+      document.activeElement instanceof HTMLInputElement ||
+      document.activeElement instanceof HTMLTextAreaElement
+    ) {
+      return
+    }
+
+    switch (e.key) {
+      // toggle fullscreen [F]
+      case 'f':
+        return utilityStore.setIsNavBarVisible(!utilityStore.isNavBarVisible)
+
+      // exit fullscreen [Esc]
+      case 'Escape':
+        return utilityStore.setIsNavBarVisible(true)
+
+      // open viewport menu [shift + V]
+      case 'V':
+        if (e.shiftKey) {
+          utilityStore.setIsViewportOpen(!utilityStore.isViewportOpen)
+        }
+        return
+
+      default:
+        return
+    }
+  }
+
+  // be sure to track changes to your states here, or they won't update when re-used
+  useEffect(() => {
+    document.addEventListener('keydown', keydownHandler)
+    return () => {
+      document.removeEventListener('keydown', keydownHandler)
+    }
+  }, [utilityStore.isNavBarVisible, utilityStore.isViewportOpen])
+}

--- a/src/components/ToggleFullscreen.tsx
+++ b/src/components/ToggleFullscreen.tsx
@@ -1,38 +1,8 @@
-import { useEffect } from 'preact/hooks'
 import { CrossCircledIcon, EnterFullScreenIcon } from '@radix-ui/react-icons'
 import { useUtilityBarStore } from '../features/utility-bar/store'
 
 export default function () {
   const utilityStore = useUtilityBarStore()
-
-  // Toggle nav bar visibility with the `f` key and exit fullscreen with the `Escape` key
-  const keydownHandler = (e: KeyboardEvent) => {
-    // Don't toggle nav bar visibility if the user is typing in an input
-    if (
-      document.activeElement instanceof HTMLInputElement ||
-      document.activeElement instanceof HTMLTextAreaElement
-    ) {
-      return
-    }
-
-    switch (e.key) {
-      case 'f':
-        return utilityStore.setIsNavBarVisible(!utilityStore.isNavBarVisible)
-
-      case 'Escape':
-        return utilityStore.setIsNavBarVisible(true)
-
-      default:
-        return
-    }
-  }
-
-  useEffect(() => {
-    document.addEventListener('keydown', keydownHandler)
-    return () => {
-      document.removeEventListener('keydown', keydownHandler)
-    }
-  }, [utilityStore.isNavBarVisible])
 
   return (
     <button

--- a/src/features/utility-bar/UtilityBar.tsx
+++ b/src/features/utility-bar/UtilityBar.tsx
@@ -28,8 +28,15 @@ export default function (props: UtilityBarProps) {
           {/* Screen Size Menu */}
           {screenSizes.length > 0 && (
             <Dropdown.Root
+              onOpenChange={() =>
+                store.setIsViewportOpen(!store.isViewportOpen)
+              }
+              open={store.isViewportOpen}
               trigger={
-                <button className="btn-subtle btn-icon" title="Viewport Size">
+                <button
+                  className="btn-subtle btn-icon"
+                  title="Viewport Size [Shift + V]"
+                >
                   <AspectRatioIcon />
                 </button>
               }

--- a/src/features/utility-bar/store.ts
+++ b/src/features/utility-bar/store.ts
@@ -4,10 +4,15 @@ import { devtools } from 'zustand/middleware'
 interface UtilityState {
   isSettingsVisible: boolean
   setIsSettingsVisible: (newVal: boolean) => void
-  activeScreenSize: ScreenSize
-  setActiveScreenSize: (newVal: ScreenSize) => void
+
+  isViewportOpen: boolean
+  setIsViewportOpen: (open: boolean) => void
+
   isNavBarVisible: boolean
   setIsNavBarVisible: (visible: boolean) => void
+
+  activeScreenSize: ScreenSize
+  setActiveScreenSize: (newVal: ScreenSize) => void
 }
 
 export enum ScreenSize {
@@ -42,11 +47,16 @@ export const useUtilityBarStore = create<UtilityState>()(
     isSettingsVisible: false,
     setIsSettingsVisible: (newVal: boolean) =>
       set(() => ({ isSettingsVisible: newVal })),
-    activeScreenSize: ScreenSize.Desktop,
-    setActiveScreenSize: (val: ScreenSize) =>
-      set(() => ({ activeScreenSize: val })),
+
+    isViewportOpen: false,
+    setIsViewportOpen: (open: boolean) => set(() => ({ isViewportOpen: open })),
+
     isNavBarVisible: true,
     setIsNavBarVisible: (visible: boolean) =>
       set(() => ({ isNavBarVisible: visible })),
+
+    activeScreenSize: ScreenSize.Desktop,
+    setActiveScreenSize: (val: ScreenSize) =>
+      set(() => ({ activeScreenSize: val })),
   })),
 )


### PR DESCRIPTION
## About
Based on the conversations in [this previous PR](https://github.com/vigetlabs/parts-kit/pull/15#issuecomment-1726689448), I went ahead and broke out `shortcuts` to their own file for maintainability and also added a new viewport menu shortcut.

I had to do some work to the Radix dropdown menu to now account for being able to access the `open` prop from outside of the button. Using `open` and `onOpenChanged` got me the control I was looking for.

Lastly, made a slight change to the `iframe` `key` value to prevent re-rendering when menu's were opening or the viewport was resizing.