### PR TITLE
Core UI improvements related to dark mode

### DIFF
--- a/config/tailwind/buttons.js
+++ b/config/tailwind/buttons.js
@@ -33,7 +33,7 @@ module.exports = plugin(({ addComponents }) => {
     },
     '.btn-subtle': {
       ...base,
-      '@apply bg-transparent text-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10':
+      '@apply bg-transparent text-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10 dark:text-gray-300 dark:active:text-white dark:enabled:active:bg-black/30 dark:enabled:hover:bg-black/20 dark:aria-expanded:bg-black/30 dark:aria-expanded:text-white':
         {},
     },
 

--- a/config/tailwind/dropdown.js
+++ b/config/tailwind/dropdown.js
@@ -3,7 +3,7 @@ const plugin = require('tailwindcss/plugin')
 module.exports = plugin(({ addComponents }) => {
   const dropdown = {
     '.dropdown': {
-      '@apply inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50':
+      '@apply inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50 dark:bg-gray-800 dark:border-gray-500 transition-colors':
         {},
 
       // handle dropdown animation
@@ -22,7 +22,7 @@ module.exports = plugin(({ addComponents }) => {
     },
 
     '.dropdown-item': {
-      '@apply cursor-pointer flex items-center px-3 min-h-8 hover:bg-black/5 hover:outline-none active:bg-black/10 w-full gap-2 justify-between rounded-md aria-checked:bg-blue-500 aria-checked:text-white aria-checked:hover:bg-blue-400 aria-checked:active:bg-blue-500':
+      '@apply cursor-pointer flex items-center px-3 min-h-8 hover:bg-black/5 hover:outline-none active:bg-black/10 w-full gap-2 justify-between rounded-md aria-checked:bg-blue-500 aria-checked:text-white aria-checked:hover:bg-blue-400 aria-checked:active:bg-blue-500 dark:text-white dark:hover:bg-black/30 dark:active:bg-black/40 aria-checked:dark:hover:bg-blue-400 aria-checked:dark:active:bg-blue-500 transition-colors':
         {},
 
       '& + &': {
@@ -31,11 +31,11 @@ module.exports = plugin(({ addComponents }) => {
     },
 
     '.dropdown-separator': {
-      '@apply h-px mx-3 bg-gray-300': {},
+      '@apply h-px mx-3 bg-gray-300 dark:bg-gray-500 transition-colors': {},
     },
 
     '.dropdown-arrow': {
-      '@apply fill-gray-300': {},
+      '@apply fill-gray-300 dark:fill-gray-400 transition-colors': {},
     },
   }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -121,7 +121,7 @@ export function App(props: AppProps) {
   return (
     <div
       className={cx(
-        'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all',
+        'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all duration-500',
         {
           '!grid-cols-[0px,1fr]': !utilityStore.isNavBarVisible,
         },

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -6,6 +6,8 @@ interface RootProps {
   trigger: JSX.Element
   children: JSX.Element
   closeable?: boolean
+  open?: boolean
+  onOpenChange?: () => void
 }
 
 const Root = (props: RootProps) => {
@@ -16,11 +18,11 @@ const Root = (props: RootProps) => {
       </DialogPrimitive.Trigger>
 
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="data-[state=open]:animate-dialog-overlay-show fixed inset-0 bg-gray-900/60 backdrop-blur-[2px]" />
-        <DialogPrimitive.Content className="data-[state=open]:animate-dialog-content-show fixed left-[50%] top-[50%] max-h-[85vh] w-[90vw] max-w-md translate-x-[-50%] translate-y-[-50%] rounded-xl border border-gray-300 bg-white px-6 py-8 shadow-lg focus:outline-none">
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-gray-900/60 backdrop-blur-[2px] data-[state=open]:animate-dialog-overlay-show" />
+        <DialogPrimitive.Content className="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-md translate-x-[-50%] translate-y-[-50%] rounded-xl border border-gray-300 bg-white px-6 py-8 shadow-lg transition-colors focus:outline-none data-[state=open]:animate-dialog-content-show dark:border-gray-500 dark:bg-gray-800 dark:text-white">
           {props.closeable && (
             <DialogPrimitive.Close asChild>
-              <button className="btn-subtle btn-icon absolute right-2 top-2">
+              <button className="absolute btn-subtle btn-icon right-2 top-2">
                 <Cross1Icon />
               </button>
             </DialogPrimitive.Close>

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'preact/hooks'
 import { useUtilityBarStore } from '../features/utility-bar/store'
+import { handleThemeClick } from '../features/utility-bar/ToggleTheme'
 
 export default function () {
   const utilityStore = useUtilityBarStore()
@@ -17,16 +18,35 @@ export default function () {
     switch (e.key) {
       // toggle fullscreen [F]
       case 'f':
+        e.preventDefault()
         return utilityStore.setIsNavBarVisible(!utilityStore.isNavBarVisible)
 
       // exit fullscreen [Esc]
       case 'Escape':
+        e.preventDefault()
         return utilityStore.setIsNavBarVisible(true)
 
-      // open viewport menu [shift + V]
+      // toggle viewport menu [Shift + V]
       case 'V':
         if (e.shiftKey) {
+          e.preventDefault()
           utilityStore.setIsViewportOpen(!utilityStore.isViewportOpen)
+        }
+        return
+
+      // toggle theme [Shift + T]
+      case 'T':
+        if (e.shiftKey) {
+          e.preventDefault()
+          handleThemeClick()
+        }
+        return
+
+      // toggle settings [Shift + S]
+      case 'S':
+        if (e.shiftKey) {
+          e.preventDefault()
+          utilityStore.setIsSettingsOpen(!utilityStore.isSettingsOpen)
         }
         return
 
@@ -41,5 +61,9 @@ export default function () {
     return () => {
       document.removeEventListener('keydown', keydownHandler)
     }
-  }, [utilityStore.isNavBarVisible, utilityStore.isViewportOpen])
+  }, [
+    utilityStore.isNavBarVisible,
+    utilityStore.isViewportOpen,
+    utilityStore.isSettingsOpen,
+  ])
 }

--- a/src/components/NavItem.tsx
+++ b/src/components/NavItem.tsx
@@ -18,11 +18,11 @@ export function NavItem(props: NavItemProps) {
     <div>
       <button
         className={cx(
-          'flex h-8 w-full items-center gap-1 rounded-none px-4 transition-colors hover:bg-black/5 active:bg-black/10',
+          'flex h-8 w-full items-center gap-1 rounded-none px-4 transition-colors hover:bg-black/5 active:bg-black/10 dark:text-gray-100 dark:hover:bg-black/30 dark:active:bg-black/40',
           {
             'py-2 font-medium': !isChild,
             'py-1 pl-8': isChild,
-            'bg-blue-500 text-white hover:bg-blue-400':
+            'bg-blue-500 text-white hover:bg-blue-400 dark:hover:bg-blue-400 dark:active:bg-blue-500':
               props.activeNavItem === props.item,
           },
         )}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -9,12 +9,12 @@ export function Search(props: SearchProps) {
   return (
     <div className="relative flex items-center">
       <MagnifyingGlassIcon
-        className="pointer-events-none absolute left-4 flex h-5 w-5 items-center text-gray-400"
+        className="absolute flex items-center w-5 h-5 text-gray-400 pointer-events-none left-4"
         aria-hidden="true"
       />
       <input
         type="search"
-        className="block h-8 w-full rounded-full bg-white pl-10 pr-2 placeholder-gray-500 ring-1 ring-gray-300 transition hover:bg-gray-50 hover:ring-gray-400 focus:outline-none focus:ring-blue-400 focus-visible:ring-2"
+        className="block w-full h-8 pl-10 pr-2 placeholder-gray-500 transition bg-white rounded-full ring-1 ring-gray-300 hover:bg-gray-50 hover:ring-gray-400 focus:outline-none focus:ring-blue-400 focus-visible:ring-2 dark:bg-gray-700 dark:text-white dark:ring-gray-500 dark:hover:bg-gray-700/75 dark:focus:ring-blue-400"
         placeholder="Search"
         aria-label="search"
         onInput={props.onInput}

--- a/src/custom-elements/parts-kit.tsx
+++ b/src/custom-elements/parts-kit.tsx
@@ -5,6 +5,19 @@ export default class PartsKit extends HTMLElement {
   constructor() {
     // Always call super first in constructor
     super()
+
+    // Setup localStorage for theme prior to app loading to prevent FOUC
+    if (
+      localStorage.theme === 'dark' ||
+      (!('theme' in localStorage) &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches)
+    ) {
+      localStorage.theme = 'dark'
+      document.documentElement.classList.add('dark')
+    } else {
+      localStorage.theme = 'light'
+      document.documentElement.classList.remove('dark')
+    }
   }
 
   connectedCallback() {

--- a/src/features/nav/Nav.tsx
+++ b/src/features/nav/Nav.tsx
@@ -32,27 +32,35 @@ export function Nav(props: NavProps) {
   return (
     <nav
       className={cx(
-        'flex min-w-[250px] flex-col gap-8 overflow-hidden bg-gray-100 bg-gradient-to-l from-gray-400/30 to-transparent to-35% py-8 transition-all',
-        {
-          'invisible opacity-0': !utilityStore.isNavBarVisible,
-        },
+        'flex min-w-[250px] flex-col gap-8 overflow-hidden bg-gray-100 bg-gradient-to-l from-gray-400/30 to-transparent to-35% py-8 transition-colors dark:bg-gray-800 dark:from-gray-900/40',
       )}
     >
-      <div className="px-6">
-        <Search onInput={(e) => setCurrentSearch(e.currentTarget.value)} />
-      </div>
+      <div
+        className={cx(
+          'flex flex-col gap-8 transition-all duration-500 ease-out',
+          {
+            'opacity-100 delay-200': utilityStore.isNavBarVisible,
+            'invisible -translate-x-2 opacity-0 delay-0':
+              !utilityStore.isNavBarVisible,
+          },
+        )}
+      >
+        <div className="px-6">
+          <Search onInput={(e) => setCurrentSearch(e.currentTarget.value)} />
+        </div>
 
-      <ul className="flex flex-col gap-2">
-        {filteredNav.map((item) => (
-          <li>
-            <NavItem
-              activeNavItem={props.activeNavItem}
-              item={item}
-              setActiveNavItem={props.setActiveNavItem}
-            />
-          </li>
-        ))}
-      </ul>
+        <ul className="flex flex-col gap-2">
+          {filteredNav.map((item) => (
+            <li>
+              <NavItem
+                activeNavItem={props.activeNavItem}
+                item={item}
+                setActiveNavItem={props.setActiveNavItem}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
     </nav>
   )
 }

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -13,12 +13,12 @@ export default function () {
           Parts JSON URL
         </label>
         <input
-          className="block h-8 w-full rounded bg-white px-4 placeholder-gray-500 ring-1 ring-gray-300 transition hover:bg-gray-50 hover:ring-gray-400 focus:outline-none focus:ring-blue-400 focus-visible:ring-2"
+          className="block h-8 w-full rounded bg-white px-4 placeholder-gray-500 ring-1 ring-gray-300 transition hover:bg-gray-50 hover:ring-gray-400 focus:outline-none focus:ring-blue-400 focus-visible:ring-2 dark:bg-gray-700 dark:text-white dark:ring-gray-500 dark:hover:bg-gray-700/75 dark:focus:ring-blue-400"
           id="parts-json-url"
           value={localNavUrl}
           onInput={(e) => setLocalNavUrl(e.currentTarget.value)}
         />
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-gray-500 transition-colors dark:text-gray-400">
           Your parts kit URLs need to have appropriate CORS and no
           X-Frame-Options restrictions. You can use a Chrome Plugin like
           Requestly to bypass these headers.

--- a/src/features/utility-bar/ToggleFullscreen.tsx
+++ b/src/features/utility-bar/ToggleFullscreen.tsx
@@ -1,5 +1,5 @@
 import { CrossCircledIcon, EnterFullScreenIcon } from '@radix-ui/react-icons'
-import { useUtilityBarStore } from '../features/utility-bar/store'
+import { useUtilityBarStore } from './store'
 
 export default function () {
   const utilityStore = useUtilityBarStore()

--- a/src/features/utility-bar/ToggleSettingsDialog.tsx
+++ b/src/features/utility-bar/ToggleSettingsDialog.tsx
@@ -1,0 +1,22 @@
+import { GearIcon } from '@radix-ui/react-icons'
+import { Dialog } from '../../components/Dialog'
+import SettingsPanel from '../../features/settings/SettingsPanel'
+import { useUtilityBarStore } from './store'
+
+export default function () {
+  const store = useUtilityBarStore()
+
+  return (
+    <Dialog.Root
+      open={store.isSettingsOpen}
+      onOpenChange={() => store.setIsSettingsOpen(!store.isSettingsOpen)}
+      trigger={
+        <button className="btn-subtle btn-icon" title="Settings [Shift + S]">
+          <GearIcon />
+        </button>
+      }
+    >
+      <SettingsPanel />
+    </Dialog.Root>
+  )
+}

--- a/src/features/utility-bar/ToggleTheme.tsx
+++ b/src/features/utility-bar/ToggleTheme.tsx
@@ -1,0 +1,23 @@
+import { BlendingModeIcon } from '@radix-ui/react-icons'
+
+export function handleThemeClick() {
+  if (localStorage.theme && localStorage.theme == 'dark') {
+    localStorage.theme = 'light'
+    document.documentElement.classList.remove('dark')
+  } else {
+    localStorage.theme = 'dark'
+    document.documentElement.classList.add('dark')
+  }
+}
+
+export default function () {
+  return (
+    <button
+      className="btn-subtle btn-icon"
+      title="Toggle Theme [Shift + T]"
+      onClick={() => handleThemeClick()}
+    >
+      <BlendingModeIcon />
+    </button>
+  )
+}

--- a/src/features/utility-bar/ToggleViewportDropdown.tsx
+++ b/src/features/utility-bar/ToggleViewportDropdown.tsx
@@ -1,0 +1,46 @@
+import { AspectRatioIcon } from '@radix-ui/react-icons'
+import {
+  screenSizes,
+  useUtilityBarStore,
+} from '../../features/utility-bar/store'
+import { Dropdown } from '../../components/Dropdown'
+
+export default function () {
+  const store = useUtilityBarStore()
+
+  return (
+    <>
+      {screenSizes.length > 0 && (
+        <Dropdown.Root
+          open={store.isViewportOpen}
+          onOpenChange={() => store.setIsViewportOpen(!store.isViewportOpen)}
+          trigger={
+            <button
+              className="btn-subtle btn-icon"
+              title="Viewport Size [Shift + V]"
+            >
+              <AspectRatioIcon />
+            </button>
+          }
+        >
+          <>
+            <Dropdown.RadioGroup value={store.activeScreenSize}>
+              {screenSizes.map((item) => (
+                <Dropdown.RadioItem
+                  key={item.size}
+                  value={item.size}
+                  onClick={() => store.setActiveScreenSize(item.size)}
+                  className="dropdown-item"
+                >
+                  {item.title}
+                </Dropdown.RadioItem>
+              ))}
+            </Dropdown.RadioGroup>
+            <Dropdown.Separator className="dropdown-separator" />
+            <Dropdown.Item className="dropdown-item">Responsive</Dropdown.Item>
+          </>
+        </Dropdown.Root>
+      )}
+    </>
+  )
+}

--- a/src/features/utility-bar/UtilityBar.tsx
+++ b/src/features/utility-bar/UtilityBar.tsx
@@ -1,13 +1,10 @@
-import { screenSizes, useUtilityBarStore } from './store'
-import SettingsPanel from '../settings/SettingsPanel'
-import { Dropdown } from '../../components/Dropdown'
-import {
-  AspectRatioIcon,
-  BlendingModeIcon,
-  GearIcon,
-} from '@radix-ui/react-icons'
-import { Dialog } from '../../components/Dialog'
-import ToggleFullscreen from '../../components/ToggleFullscreen'
+import { useUtilityBarStore } from './store'
+import cx from 'classnames'
+
+import ToggleFullscreen from './ToggleFullscreen'
+import ToggleTheme from './ToggleTheme'
+import ToggleViewportDropdown from './ToggleViewportDropdown'
+import ToggleSettingsDialog from './ToggleSettingsDialog'
 
 interface UtilityBarProps {
   showSettings: boolean
@@ -18,64 +15,25 @@ export default function (props: UtilityBarProps) {
 
   return (
     <div>
-      <header className="flex justify-between h-10 gap-4 px-4 bg-gray-100 border-l border-white">
+      <header
+        className={cx(
+          'flex h-10 justify-between gap-4 border-l border-white bg-gray-100 px-4 transition dark:border-gray-500 dark:bg-gray-700',
+          {
+            'border-gray-100 dark:border-gray-700': !store.isNavBarVisible,
+          },
+        )}
+      >
         <div className="flex items-center gap-2">
           {/* Theme Control */}
-          <button className="btn-subtle btn-icon" title="Theme">
-            <BlendingModeIcon />
-          </button>
+          <ToggleTheme />
 
-          {/* Screen Size Menu */}
-          {screenSizes.length > 0 && (
-            <Dropdown.Root
-              onOpenChange={() =>
-                store.setIsViewportOpen(!store.isViewportOpen)
-              }
-              open={store.isViewportOpen}
-              trigger={
-                <button
-                  className="btn-subtle btn-icon"
-                  title="Viewport Size [Shift + V]"
-                >
-                  <AspectRatioIcon />
-                </button>
-              }
-            >
-              <>
-                <Dropdown.RadioGroup value={store.activeScreenSize}>
-                  {screenSizes.map((item) => (
-                    <Dropdown.RadioItem
-                      key={item.size}
-                      value={item.size}
-                      onClick={() => store.setActiveScreenSize(item.size)}
-                      className="dropdown-item"
-                    >
-                      {item.title}
-                    </Dropdown.RadioItem>
-                  ))}
-                </Dropdown.RadioGroup>
-                <Dropdown.Separator className="dropdown-separator" />
-                <Dropdown.Item className="dropdown-item">
-                  Responsive
-                </Dropdown.Item>
-              </>
-            </Dropdown.Root>
-          )}
+          {/* Viewport Dropdown Controls */}
+          <ToggleViewportDropdown />
         </div>
 
         <div className="flex items-center gap-2">
-          {/* Show / Hide Settings */}
-          {props.showSettings && (
-            <Dialog.Root
-              trigger={
-                <button className="btn-subtle btn-icon" title="Settings">
-                  <GearIcon />
-                </button>
-              }
-            >
-              <SettingsPanel />
-            </Dialog.Root>
-          )}
+          {/* Settings Control */}
+          {props.showSettings && <ToggleSettingsDialog />}
 
           {/* Fullscreen control */}
           <ToggleFullscreen />

--- a/src/features/utility-bar/store.ts
+++ b/src/features/utility-bar/store.ts
@@ -5,6 +5,9 @@ interface UtilityState {
   isSettingsVisible: boolean
   setIsSettingsVisible: (newVal: boolean) => void
 
+  isSettingsOpen: boolean
+  setIsSettingsOpen: (open: boolean) => void
+
   isViewportOpen: boolean
   setIsViewportOpen: (open: boolean) => void
 
@@ -47,6 +50,9 @@ export const useUtilityBarStore = create<UtilityState>()(
     isSettingsVisible: false,
     setIsSettingsVisible: (newVal: boolean) =>
       set(() => ({ isSettingsVisible: newVal })),
+
+    isSettingsOpen: false,
+    setIsSettingsOpen: (open: boolean) => set(() => ({ isSettingsOpen: open })),
 
     isViewportOpen: false,
     setIsViewportOpen: (open: boolean) => set(() => ({ isViewportOpen: open })),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ const colors = require('tailwindcss/colors')
 
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
   theme: {
     screens: {
       sm: '550px',


### PR DESCRIPTION
## Issue
- #16 

## About
This PR primarily handles adding a dark mode theme to the project, but I also went ahead and made some refactors to utility bar, as well as fixed up some minor bugs.

It's worth calling out that changing the theme has no bearing on the actual `iframe`. I think it's best we don't be overly strict with respect to any type of theming of the content itself, so for that reason the theming is isolated only to our part kits interface.

## Changelog
#### Updates
- Parts Kit themed for dark mode
  - Change includes [updating Figma](https://www.figma.com/file/2GYsIBmO4lNF5GHwk7es7d/Parts-Kit?type=design&node-id=0%3A1&mode=design&t=bfRqncb5V9l7loKM-1) to have two color profiles `'light' | 'dark'`. 
- Theme controller and `localStorage` set up
  - Theme will default to user's OS preference. Should the user make a change to the theme, we'll capture that in `localStorage` and preserve it upon reloading the page.
- Utility Bar Refactor
  - All control buttons have been moved to their own files to clean up the directory and logic a bit more
- Nav (sidebar) has updated transition animation
 
#### Bug Fixes
- Settings modal is now on the top of the screen when opened

## Preview
#### Demo
![dark-mode](https://github.com/vigetlabs/parts-kit/assets/8878152/2b92db5c-b3de-477f-8e84-be312ce0acd3)

#### Figma Dark Mode account for
![image](https://github.com/vigetlabs/parts-kit/assets/8878152/ddfb6391-6df8-4c04-9759-adbb04700f0b)

