### PR TITLE
Scoped the parts kit styles to a unique ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <title>Vite + Preact + TS</title>
   </head>
-  <body id="parts-kit">
+  <body>
     <parts-kit></parts-kit>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <title>Vite + Preact + TS</title>
   </head>
-  <body>
+  <body id="parts-kit">
     <parts-kit></parts-kit>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -118,49 +118,51 @@ export function App(props: AppProps) {
   KeyboardShortcuts()
 
   return (
-    <div
-      className={cx(
-        'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all duration-500',
-        {
-          '!grid-cols-[0px,1fr]': !utilityStore.isNavBarVisible,
-        },
-      )}
-    >
-      {activeNavItem !== undefined ? (
-        <Nav
-          activeNavItem={activeNavItem}
-          nav={config.nav}
-          setActiveNavItem={setViableNavItem}
-        />
-      ) : null}
+    <div id="parts-kit">
+      <div
+        className={cx(
+          'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all duration-500',
+          {
+            '!grid-cols-[0px,1fr]': !utilityStore.isNavBarVisible,
+          },
+        )}
+      >
+        {activeNavItem !== undefined ? (
+          <Nav
+            activeNavItem={activeNavItem}
+            nav={config.nav}
+            setActiveNavItem={setViableNavItem}
+          />
+        ) : null}
 
-      <div className="relative z-10 flex flex-col bg-white">
-        <UtilityBar
-          isDoc={activeNavItem?.doc ?? false}
-          showSettings={!hasConfigUrl}
-        />
+        <div className="relative z-10 flex flex-col bg-white">
+          <UtilityBar
+            isDoc={activeNavItem?.doc ?? false}
+            showSettings={!hasConfigUrl}
+          />
 
-        <div className="flex flex-grow items-stretch justify-center">
-          {!hasConfigUrl && isWelcomeVisible ? (
-            <Welcome />
-          ) : (
-            <div
-              className={cx('flex-grow', {
-                'py-5': utilityStore.activeScreenSize !== ScreenSize.Desktop,
-              })}
-              style={{ maxWidth: activeScreenWidth }}
-            >
-              {/* Changing the src of iframes will muck up your history. Using key to rerender when the nav changes is a workaround */}
-              <iframe
-                key={activeNavItem?.url}
-                className={cx('h-full w-full', {
-                  'rounded border-2 border-gray-100':
-                    utilityStore.activeScreenSize !== ScreenSize.Desktop,
+          <div className="flex flex-grow items-stretch justify-center">
+            {!hasConfigUrl && isWelcomeVisible ? (
+              <Welcome />
+            ) : (
+              <div
+                className={cx('flex-grow', {
+                  'py-5': utilityStore.activeScreenSize !== ScreenSize.Desktop,
                 })}
-                src={activeNavItem?.url ?? undefined}
-              ></iframe>
-            </div>
-          )}
+                style={{ maxWidth: activeScreenWidth }}
+              >
+                {/* Changing the src of iframes will muck up your history. Using key to rerender when the nav changes is a workaround */}
+                <iframe
+                  key={activeNavItem?.url}
+                  className={cx('h-full w-full', {
+                    'rounded border-2 border-gray-100':
+                      utilityStore.activeScreenSize !== ScreenSize.Desktop,
+                  })}
+                  src={activeNavItem?.url ?? undefined}
+                ></iframe>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ const colors = require('tailwindcss/colors')
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',
+  important: '#parts-kit',
   theme: {
     screens: {
       sm: '550px',


### PR DESCRIPTION
## About
While working on [Blueprint](https://github.com/vigetlabs/blueprint/) we ran into an issue where some of the locally modified styles for that project were conflicting with the Parts Kit chrome styles. Since this is something that can happen pretty easily, I thought it might be best to scope our Parts Kit styles to prevent this from occurring.

I opted to go for the simple [Selector Strategy](https://tailwindcss.com/docs/configuration#selector-strategy) which allows us to scope all of the TW styles to a specific class or ID. In this case, I've added the ID of `parts-kit` to the `body` and now all of the styles are locked into this specific project.