### PR TITLE
Scoped plugins to `#parts-kit`

### DIFF
--- a/config/tailwind/buttons.js
+++ b/config/tailwind/buttons.js
@@ -21,24 +21,24 @@ module.exports = plugin(({ addComponents }) => {
 
   const buttons = {
     // Variants
-    '.btn': {
+    '#parts-kit .btn': {
       ...base,
       '@apply bg-blue-500 text-white enabled:hover:bg-blue-600 enabled:active:bg-blue-700 aria-expanded:bg-blue-700':
         {},
     },
-    '.btn-outline': {
+    '#parts-kit .btn-outline': {
       ...base,
       '@apply bg-transparent text-gray-600 border border-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10':
         {},
     },
-    '.btn-subtle': {
+    '#parts-kit .btn-subtle': {
       ...base,
       '@apply bg-transparent text-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10 dark:text-gray-300 dark:active:text-white dark:enabled:active:bg-black/30 dark:enabled:hover:bg-black/20 dark:aria-expanded:bg-black/30 dark:aria-expanded:text-white':
         {},
     },
 
     // Icon buttons (uses base variants for styling)
-    '.btn-icon': {
+    '#parts-kit .btn-icon': {
       '@apply !gap-0 !p-0 w-6 h-6 !leading-[0] !text-[0]': {},
 
       '& svg': {

--- a/config/tailwind/dropdown.js
+++ b/config/tailwind/dropdown.js
@@ -2,7 +2,7 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = plugin(({ addComponents }) => {
   const dropdown = {
-    '.dropdown': {
+    '#parts-kit .dropdown': {
       '@apply inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50 dark:bg-gray-800 dark:border-gray-500 transition-colors':
         {},
 
@@ -21,7 +21,7 @@ module.exports = plugin(({ addComponents }) => {
       },
     },
 
-    '.dropdown-item': {
+    '#parts-kit .dropdown-item': {
       '@apply cursor-pointer flex items-center px-3 min-h-8 hover:bg-black/5 hover:outline-none active:bg-black/10 w-full gap-2 justify-between rounded-md aria-checked:bg-blue-500 aria-checked:text-white aria-checked:hover:bg-blue-400 aria-checked:active:bg-blue-500 dark:text-white dark:hover:bg-black/30 dark:active:bg-black/40 aria-checked:dark:hover:bg-blue-400 aria-checked:dark:active:bg-blue-500 transition-colors':
         {},
 
@@ -30,11 +30,11 @@ module.exports = plugin(({ addComponents }) => {
       },
     },
 
-    '.dropdown-separator': {
+    '#parts-kit .dropdown-separator': {
       '@apply h-px mx-3 bg-gray-300 dark:bg-gray-500 transition-colors': {},
     },
 
-    '.dropdown-arrow': {
+    '#parts-kit .dropdown-arrow': {
       '@apply fill-gray-300 dark:fill-gray-400 transition-colors': {},
     },
   }

--- a/config/tailwind/icons.js
+++ b/config/tailwind/icons.js
@@ -2,10 +2,10 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = plugin(({ addComponents }) => {
   const icons = {
-    '.icon': {
+    '#parts-kit .icon': {
       '@apply h-4 w-4': {},
     },
-    '.icon-lg': {
+    '#parts-kit .icon-lg': {
       '@apply h-5 w-5': {},
     },
   }

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -17,12 +17,12 @@ const Root = (props: RootProps) => {
         {props.trigger && props.trigger}
       </DialogPrimitive.Trigger>
 
-      <DialogPrimitive.Portal>
+      <DialogPrimitive.Portal container={document.getElementById('parts-kit')}>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-gray-900/60 backdrop-blur-[2px] data-[state=open]:animate-dialog-overlay-show" />
         <DialogPrimitive.Content className="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-md translate-x-[-50%] translate-y-[-50%] rounded-xl border border-gray-300 bg-white px-6 py-8 shadow-lg transition-colors focus:outline-none data-[state=open]:animate-dialog-content-show dark:border-gray-500 dark:bg-gray-800 dark:text-white">
           {props.closeable && (
             <DialogPrimitive.Close asChild>
-              <button className="absolute btn-subtle btn-icon right-2 top-2">
+              <button className="btn-subtle btn-icon absolute right-2 top-2">
                 <Cross1Icon />
               </button>
             </DialogPrimitive.Close>

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -18,7 +18,7 @@ const Root = (props: RootProps) => {
         {props.trigger && props.trigger}
       </DropdownMenu.Trigger>
 
-      <DropdownMenu.Portal>
+      <DropdownMenu.Portal container={document.getElementById('parts-kit')}>
         <DropdownMenu.Content
           sideOffset={5}
           align={props.align || 'start'}


### PR DESCRIPTION
I came across two bugs from the previous `#parts-kit` styling declaration. It turns out that plugins do not extend that naming convention, so I applied the inheritance to the plugins.

The second issue I came across was in the form of the Radix elements. By default, they were applying the `dropdown` and `dialog` expanded containers to `document.body` which meant that they existed outside of the scope of our `#parts-kit` ID. I updated the portal location to exist within the React app to resolve this issue.