### PR TITLE
Updated styling scope (again)

### DIFF
--- a/config/tailwind/buttons.js
+++ b/config/tailwind/buttons.js
@@ -3,46 +3,46 @@ const plugin = require('tailwindcss/plugin')
 module.exports = plugin(({ addComponents }) => {
   // Base styles
   const base = {
-    '@apply inline-flex font-medium transition-colors items-center justify-center text-center focus:outline-none shrink-0 rounded focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2':
+    '@apply pk-inline-flex pk-font-medium pk-transition-colors pk-items-center pk-justify-center pk-text-center focus:pk-outline-none pk-shrink-0 pk-rounded focus-visible:pk-ring-2 focus-visible:pk-ring-black focus-visible:pk-ring-offset-2':
       {},
     '&:not(.btn-icon)': {
-      '@apply min-h-10 px-5 py-2 gap-2': {},
+      '@apply pk-min-h-10 pk-px-5 pk-py-2 pk-gap-2': {},
     },
     '&:not(.btn-icon) svg': {
-      '@apply -mx-0.5': {}, // handles icon padding offset
+      '@apply -pk-mx-0.5': {}, // handles icon padding offset
     },
     '& svg': {
-      '@apply w-5 h-5 shrink-0': {},
+      '@apply pk-w-5 pk-h-5 pk-shrink-0': {},
     },
     '&:disabled': {
-      '@apply cursor-not-allowed opacity-50': {},
+      '@apply pk-cursor-not-allowed pk-opacity-50': {},
     },
   }
 
   const buttons = {
     // Variants
-    '#parts-kit .btn': {
+    '.btn': {
       ...base,
-      '@apply bg-blue-500 text-white enabled:hover:bg-blue-600 enabled:active:bg-blue-700 aria-expanded:bg-blue-700':
+      '@apply pk-bg-blue-500 pk-text-white enabled:hover:pk-bg-blue-600 enabled:active:pk-bg-blue-700 aria-expanded:pk-bg-blue-700':
         {},
     },
-    '#parts-kit .btn-outline': {
+    '.btn-outline': {
       ...base,
-      '@apply bg-transparent text-gray-600 border border-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10':
+      '@apply pk-bg-transparent pk-text-gray-600 pk-border pk-border-gray-600 enabled:hover:pk-bg-black/5 enabled:active:pk-bg-black/10 aria-expanded:pk-bg-black/10':
         {},
     },
-    '#parts-kit .btn-subtle': {
+    '.btn-subtle': {
       ...base,
-      '@apply bg-transparent text-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10 dark:text-gray-300 dark:active:text-white dark:enabled:active:bg-black/30 dark:enabled:hover:bg-black/20 dark:aria-expanded:bg-black/30 dark:aria-expanded:text-white':
+      '@apply pk-bg-transparent pk-text-gray-600 enabled:hover:pk-bg-black/5 enabled:active:pk-bg-black/10 aria-expanded:pk-bg-black/10 dark:pk-text-gray-300 dark:active:pk-text-white dark:enabled:active:pk-bg-black/30 dark:enabled:hover:pk-bg-black/20 dark:aria-expanded:pk-bg-black/30 dark:aria-expanded:pk-text-white':
         {},
     },
 
     // Icon buttons (uses base variants for styling)
-    '#parts-kit .btn-icon': {
-      '@apply !gap-0 !p-0 w-6 h-6 !leading-[0] !text-[0]': {},
+    '.btn-icon': {
+      '@apply !pk-gap-0 !pk-p-0 pk-w-6 pk-h-6 !pk-leading-[0] !pk-text-[0]': {},
 
       '& svg': {
-        '@apply w-4 h-4 shrink-0': {},
+        '@apply pk-w-4 pk-h-4 pk-shrink-0': {},
       },
     },
   }

--- a/config/tailwind/dropdown.js
+++ b/config/tailwind/dropdown.js
@@ -2,8 +2,8 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = plugin(({ addComponents }) => {
   const dropdown = {
-    '#parts-kit .dropdown': {
-      '@apply inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50 dark:bg-gray-800 dark:border-gray-500 transition-colors':
+    '.dropdown': {
+      '@apply pk-inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50 dark:bg-gray-800 dark:border-gray-500 transition-colors':
         {},
 
       // handle dropdown animation
@@ -21,7 +21,7 @@ module.exports = plugin(({ addComponents }) => {
       },
     },
 
-    '#parts-kit .dropdown-item': {
+    '.dropdown-item': {
       '@apply cursor-pointer flex items-center px-3 min-h-8 hover:bg-black/5 hover:outline-none active:bg-black/10 w-full gap-2 justify-between rounded-md aria-checked:bg-blue-500 aria-checked:text-white aria-checked:hover:bg-blue-400 aria-checked:active:bg-blue-500 dark:text-white dark:hover:bg-black/30 dark:active:bg-black/40 aria-checked:dark:hover:bg-blue-400 aria-checked:dark:active:bg-blue-500 transition-colors':
         {},
 
@@ -30,11 +30,11 @@ module.exports = plugin(({ addComponents }) => {
       },
     },
 
-    '#parts-kit .dropdown-separator': {
+    '.dropdown-separator': {
       '@apply h-px mx-3 bg-gray-300 dark:bg-gray-500 transition-colors': {},
     },
 
-    '#parts-kit .dropdown-arrow': {
+    '.dropdown-arrow': {
       '@apply fill-gray-300 dark:fill-gray-400 transition-colors': {},
     },
   }

--- a/config/tailwind/dropdown.js
+++ b/config/tailwind/dropdown.js
@@ -3,39 +3,40 @@ const plugin = require('tailwindcss/plugin')
 module.exports = plugin(({ addComponents }) => {
   const dropdown = {
     '.dropdown': {
-      '@apply pk-inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50 dark:bg-gray-800 dark:border-gray-500 transition-colors':
+      '@apply pk-inline-flex pk-flex-col pk-gap-2 pk-p-2 pk-bg-white pk-border pk-border-gray-300 pk-shadow pk-min-w-[200px] pk-max-w-[250px] pk-rounded-xl pk-z-50 dark:pk-bg-gray-800 dark:pk-border-gray-500 pk-transition-colors':
         {},
 
       // handle dropdown animation
       '&[data-side="top"]': {
-        '@apply animate-slide-down-and-fade': {},
+        '@apply pk-animate-slide-down-and-fade': {},
       },
       '&[data-side="bottom"]': {
-        '@apply animate-slide-up-and-fade': {},
+        '@apply pk-animate-slide-up-and-fade': {},
       },
       '&[data-side="left"]': {
-        '@apply animate-slide-right-and-fade': {},
+        '@apply pk-animate-slide-right-and-fade': {},
       },
       '&[data-side="right"]': {
-        '@apply animate-slide-left-and-fade': {},
+        '@apply pk-animate-slide-left-and-fade': {},
       },
     },
 
     '.dropdown-item': {
-      '@apply cursor-pointer flex items-center px-3 min-h-8 hover:bg-black/5 hover:outline-none active:bg-black/10 w-full gap-2 justify-between rounded-md aria-checked:bg-blue-500 aria-checked:text-white aria-checked:hover:bg-blue-400 aria-checked:active:bg-blue-500 dark:text-white dark:hover:bg-black/30 dark:active:bg-black/40 aria-checked:dark:hover:bg-blue-400 aria-checked:dark:active:bg-blue-500 transition-colors':
+      '@apply pk-cursor-pointer pk-flex pk-items-center pk-px-3 pk-min-h-8 hover:pk-bg-black/5 hover:pk-outline-none active:pk-bg-black/10 pk-w-full pk-gap-2 pk-justify-between pk-rounded-md aria-checked:pk-bg-blue-500 aria-checked:pk-text-white aria-checked:hover:pk-bg-blue-400 aria-checked:active:pk-bg-blue-500 dark:pk-text-white dark:hover:pk-bg-black/30 dark:active:pk-bg-black/40 aria-checked:dark:hover:pk-bg-blue-400 aria-checked:dark:active:pk-bg-blue-500 pk-transition-colors':
         {},
 
       '& + &': {
-        '@apply mt-1': {},
+        '@apply pk-mt-1': {},
       },
     },
 
     '.dropdown-separator': {
-      '@apply h-px mx-3 bg-gray-300 dark:bg-gray-500 transition-colors': {},
+      '@apply pk-h-px pk-mx-3 pk-bg-gray-300 dark:pk-bg-gray-500 pk-transition-colors':
+        {},
     },
 
     '.dropdown-arrow': {
-      '@apply fill-gray-300 dark:fill-gray-400 transition-colors': {},
+      '@apply pk-fill-gray-300 dark:pk-fill-gray-400 pk-transition-colors': {},
     },
   }
 

--- a/config/tailwind/icons.js
+++ b/config/tailwind/icons.js
@@ -2,11 +2,11 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = plugin(({ addComponents }) => {
   const icons = {
-    '#parts-kit .icon': {
-      '@apply h-4 w-4': {},
+    '.icon': {
+      '@apply pk-h-4 pk-w-4': {},
     },
-    '#parts-kit .icon-lg': {
-      '@apply h-5 w-5': {},
+    '.icon-lg': {
+      '@apply pk-h-5 pk-w-5': {},
     },
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "vite": "^4.4.5",
         "vite-plugin-css-injected-by-js": "^3.3.0",
         "vitest": "^0.34.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -121,9 +121,9 @@ export function App(props: AppProps) {
     <div id="parts-kit">
       <div
         className={cx(
-          'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all duration-500',
+          'pk-grid pk-h-screen pk-grid-cols-[250px,1fr] pk-bg-gray-100 pk-transition-all pk-duration-500',
           {
-            '!grid-cols-[0px,1fr]': !utilityStore.isNavBarVisible,
+            '!pk-grid-cols-[0px,1fr]': !utilityStore.isNavBarVisible,
           },
         )}
       >
@@ -135,27 +135,28 @@ export function App(props: AppProps) {
           />
         ) : null}
 
-        <div className="relative z-10 flex flex-col bg-white">
+        <div className="pk-relative pk-z-10 pk-flex pk-flex-col pk-bg-white">
           <UtilityBar
             isDoc={activeNavItem?.doc ?? false}
             showSettings={!hasConfigUrl}
           />
 
-          <div className="flex flex-grow items-stretch justify-center">
+          <div className="pk-flex pk-flex-grow pk-items-stretch pk-justify-center">
             {!hasConfigUrl && isWelcomeVisible ? (
               <Welcome />
             ) : (
               <div
-                className={cx('flex-grow', {
-                  'py-5': utilityStore.activeScreenSize !== ScreenSize.Desktop,
+                className={cx('pk-flex-grow', {
+                  'pk-py-5':
+                    utilityStore.activeScreenSize !== ScreenSize.Desktop,
                 })}
                 style={{ maxWidth: activeScreenWidth }}
               >
                 {/* Changing the src of iframes will muck up your history. Using key to rerender when the nav changes is a workaround */}
                 <iframe
                   key={activeNavItem?.url}
-                  className={cx('h-full w-full', {
-                    'rounded border-2 border-gray-100':
+                  className={cx('pk-h-full pk-w-full', {
+                    'pk-rounded pk-border-2 pk-border-gray-100':
                       utilityStore.activeScreenSize !== ScreenSize.Desktop,
                   })}
                   src={activeNavItem?.url ?? undefined}

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -18,11 +18,11 @@ const Root = (props: RootProps) => {
       </DialogPrimitive.Trigger>
 
       <DialogPrimitive.Portal container={document.getElementById('parts-kit')}>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-gray-900/60 backdrop-blur-[2px] data-[state=open]:animate-dialog-overlay-show" />
-        <DialogPrimitive.Content className="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-md translate-x-[-50%] translate-y-[-50%] rounded-xl border border-gray-300 bg-white px-6 py-8 shadow-lg transition-colors focus:outline-none data-[state=open]:animate-dialog-content-show dark:border-gray-500 dark:bg-gray-800 dark:text-white">
+        <DialogPrimitive.Overlay className="pk-fixed pk-inset-0 pk-z-50 pk-bg-gray-900/60 pk-backdrop-blur-[2px] data-[state=open]:pk-animate-dialog-overlay-show" />
+        <DialogPrimitive.Content className="pk-fixed pk-left-[50%] pk-top-[50%] pk-z-50 pk-max-h-[85vh] pk-w-[90vw] pk-max-w-md pk-translate-x-[-50%] pk-translate-y-[-50%] pk-rounded-xl pk-border pk-border-gray-300 pk-bg-white pk-px-6 pk-py-8 pk-shadow-lg pk-transition-colors focus:pk-outline-none data-[state=open]:pk-animate-dialog-content-show dark:pk-border-gray-500 dark:pk-bg-gray-800 dark:pk-text-white">
           {props.closeable && (
             <DialogPrimitive.Close asChild>
-              <button className="btn-subtle btn-icon absolute right-2 top-2">
+              <button className="pk-btn-subtle pk-btn-icon pk-absolute pk-right-2 pk-top-2">
                 <Cross1Icon />
               </button>
             </DialogPrimitive.Close>

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -23,10 +23,12 @@ const Root = (props: RootProps) => {
           sideOffset={5}
           align={props.align || 'start'}
           side={props.side || 'bottom'}
-          className="dropdown"
+          className="pk-dropdown"
         >
           {props.children}
-          {props.hasArrow && <DropdownMenu.Arrow className="dropdown-arrow" />}
+          {props.hasArrow && (
+            <DropdownMenu.Arrow className="pk-dropdown-arrow" />
+          )}
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/src/components/NavItem.tsx
+++ b/src/components/NavItem.tsx
@@ -66,11 +66,11 @@ export function NavItem(props: NavItemProps) {
     <li>
       <button
         className={cx(
-          'flex min-h-8 w-full items-center gap-1 rounded-none px-4 text-start transition-colors hover:bg-black/5 active:bg-black/10 dark:text-gray-100 dark:hover:bg-black/30 dark:active:bg-black/40',
+          'pk-flex pk-min-h-8 pk-w-full pk-items-center pk-gap-1 pk-rounded-none pk-px-4 pk-text-start pk-transition-colors hover:pk-bg-black/5 active:pk-bg-black/10 dark:pk-text-gray-100 dark:hover:pk-bg-black/30 dark:active:pk-bg-black/40',
           {
-            'py-2 font-medium': !isChild || props.item.children.length,
-            'py-1 pl-4': isChild,
-            'bg-blue-500 text-white hover:bg-blue-400 dark:hover:bg-blue-400 dark:active:bg-blue-500':
+            'pk-py-2 pk-font-medium': !isChild || props.item.children.length,
+            'pk-py-1 pk-pl-4': isChild,
+            'pk-bg-blue-500 pk-text-white hover:pk-bg-blue-400 dark:hover:pk-bg-blue-400 dark:active:pk-bg-blue-500':
               props.activeNavItem === props.item,
           },
         )}
@@ -89,18 +89,18 @@ export function NavItem(props: NavItemProps) {
         {props.item.children.length ? (
           <>
             <ChevronRightIcon
-              className={cx('icon -ml-1', {
-                hidden: isOpen,
+              className={cx('pk-icon -pk-ml-1', {
+                'pk-hidden': isOpen,
               })}
             />
             <ChevronDownIcon
-              className={cx('icon -ml-1', {
-                hidden: !isOpen,
+              className={cx('pk-icon -pk-ml-1', {
+                'pk-hidden': !isOpen,
               })}
             />
           </>
         ) : !isChild ? (
-          <span className="w-3" /> // spacer
+          <span className="pk-w-3" /> // spacer
         ) : null}
         {props.item.title}
       </button>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -7,14 +7,14 @@ interface SearchProps {
 
 export function Search(props: SearchProps) {
   return (
-    <div className="relative flex items-center">
+    <div className="pk-relative pk-flex pk-items-center">
       <MagnifyingGlassIcon
-        className="absolute flex items-center w-5 h-5 text-gray-400 pointer-events-none left-4"
+        className="pk-pointer-events-none pk-absolute pk-left-4 pk-flex pk-h-5 pk-w-5 pk-items-center pk-text-gray-400"
         aria-hidden="true"
       />
       <input
         type="search"
-        className="block w-full h-8 pl-10 pr-2 placeholder-gray-500 transition bg-white rounded-full ring-1 ring-gray-300 hover:bg-gray-50 hover:ring-gray-400 focus:outline-none focus:ring-blue-400 focus-visible:ring-2 dark:bg-gray-700 dark:text-white dark:ring-gray-500 dark:hover:bg-gray-700/75 dark:focus:ring-blue-400"
+        className="pk-block pk-h-8 pk-w-full pk-rounded-full pk-bg-white pk-pl-10 pk-pr-2 pk-placeholder-gray-500 pk-ring-1 pk-ring-gray-300 pk-transition hover:pk-bg-gray-50 hover:pk-ring-gray-400 focus:pk-outline-none focus:pk-ring-blue-400 focus-visible:pk-ring-2 dark:pk-bg-gray-700 dark:pk-text-white dark:pk-ring-gray-500 dark:hover:pk-bg-gray-700/75 dark:focus:pk-ring-blue-400"
         placeholder="Search"
         aria-label="search"
         onInput={props.onInput}

--- a/src/features/nav/Nav.tsx
+++ b/src/features/nav/Nav.tsx
@@ -54,20 +54,20 @@ export function Nav(props: NavProps) {
   return (
     <nav
       className={cx(
-        'flex min-w-[250px] flex-col gap-8 overflow-hidden bg-gray-100 bg-gradient-to-l from-gray-400/30 to-transparent to-35% transition-colors dark:bg-gray-800 dark:from-gray-900/40',
+        'to-35% pk-flex pk-min-w-[250px] pk-flex-col pk-gap-8 pk-overflow-hidden pk-bg-gray-100 pk-bg-gradient-to-l pk-from-gray-400/30 pk-to-transparent pk-transition-colors dark:pk-bg-gray-800 dark:pk-from-gray-900/40',
       )}
     >
       <div
         className={cx(
-          'grid grid-rows-[auto,1fr] h-full gap-6 transition-all duration-500 ease-out',
+          'pk-grid pk-h-full pk-grid-rows-[auto,1fr] pk-gap-6 pk-transition-all pk-duration-500 pk-ease-out',
           {
-            'opacity-100 delay-200': utilityStore.isNavBarVisible,
-            'invisible -translate-x-2 opacity-0 delay-0':
+            'pk-opacity-100 pk-delay-200': utilityStore.isNavBarVisible,
+            'pk-invisible -pk-translate-x-2 pk-opacity-0 pk-delay-0':
               !utilityStore.isNavBarVisible,
           },
         )}
       >
-        <div className="px-6 pt-6">
+        <div className="pk-px-6 pk-pt-6">
           <Search
             onInput={(e) =>
               setCurrentSearch(e.currentTarget.value.toLowerCase())
@@ -75,7 +75,7 @@ export function Nav(props: NavProps) {
           />
         </div>
 
-        <ul className="flex flex-col gap-2 overflow-auto pb-6">
+        <ul className="pk-flex pk-flex-col pk-gap-2 pk-overflow-auto pk-pb-6">
           {filteredNav.map((item) => (
             <NavItem
               activeNavItem={props.activeNavItem}

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -6,26 +6,29 @@ export default function () {
   const settings = useSettingsStore()
   const [localNavUrl, setLocalNavUrl] = useState(settings.configUrl)
   return (
-    <div className="flex flex-col gap-6">
-      <h2 className="text-md font-bold uppercase">Settings</h2>
-      <div className="flex flex-col gap-2">
-        <label className="text-xs font-medium uppercase" for="parts-json-url">
+    <div className="pk-flex pk-flex-col pk-gap-6">
+      <h2 className="pk-text-md pk-font-bold pk-uppercase">Settings</h2>
+      <div className="pk-flex pk-flex-col pk-gap-2">
+        <label
+          className="pk-text-xs pk-font-medium pk-uppercase"
+          for="parts-json-url"
+        >
           Parts JSON URL
         </label>
         <input
-          className="block h-8 w-full rounded bg-white px-4 placeholder-gray-500 ring-1 ring-gray-300 transition hover:bg-gray-50 hover:ring-gray-400 focus:outline-none focus:ring-blue-400 focus-visible:ring-2 dark:bg-gray-700 dark:text-white dark:ring-gray-500 dark:hover:bg-gray-700/75 dark:focus:ring-blue-400"
+          className="pk-block pk-h-8 pk-w-full pk-rounded pk-bg-white pk-px-4 pk-placeholder-gray-500 pk-ring-1 pk-ring-gray-300 pk-transition hover:pk-bg-gray-50 hover:pk-ring-gray-400 focus:pk-outline-none focus:pk-ring-blue-400 focus-visible:pk-ring-2 dark:pk-bg-gray-700 dark:pk-text-white dark:pk-ring-gray-500 dark:hover:pk-bg-gray-700/75 dark:focus:pk-ring-blue-400"
           id="parts-json-url"
           value={localNavUrl}
           onInput={(e) => setLocalNavUrl(e.currentTarget.value)}
         />
-        <p className="text-xs text-gray-500 transition-colors dark:text-gray-400">
+        <p className="pk-text-xs pk-text-gray-500 pk-transition-colors dark:pk-text-gray-400">
           Your parts kit URLs need to have appropriate CORS and no
           X-Frame-Options restrictions. You can use a Chrome Plugin like
           Requestly to bypass these headers.
         </p>
       </div>
-      <div className="flex justify-end gap-2">
-        <Dialog.Close className="btn-outline">Cancel</Dialog.Close>
+      <div className="pk-flex pk-justify-end pk-gap-2">
+        <Dialog.Close className="pk-btn-outline">Cancel</Dialog.Close>
         <Dialog.Close
           className="btn"
           onClick={() =>

--- a/src/features/utility-bar/ToggleFullscreen.tsx
+++ b/src/features/utility-bar/ToggleFullscreen.tsx
@@ -6,7 +6,7 @@ export default function () {
 
   return (
     <button
-      className="btn-subtle btn-icon"
+      className="pk-btn-subtle pk-btn-icon"
       title={
         utilityStore.isNavBarVisible
           ? 'Go Fullscreen [F]'

--- a/src/features/utility-bar/ToggleSettingsDialog.tsx
+++ b/src/features/utility-bar/ToggleSettingsDialog.tsx
@@ -11,7 +11,10 @@ export default function () {
       open={store.isSettingsOpen}
       onOpenChange={() => store.setIsSettingsOpen(!store.isSettingsOpen)}
       trigger={
-        <button className="btn-subtle btn-icon" title="Settings [Shift + S]">
+        <button
+          className="pk-btn-subtle pk-btn-icon"
+          title="Settings [Shift + S]"
+        >
           <GearIcon />
         </button>
       }

--- a/src/features/utility-bar/ToggleTheme.tsx
+++ b/src/features/utility-bar/ToggleTheme.tsx
@@ -13,7 +13,7 @@ export function handleThemeClick() {
 export default function () {
   return (
     <button
-      className="btn-subtle btn-icon"
+      className="pk-btn-subtle pk-btn-icon"
       title="Toggle Theme [Shift + T]"
       onClick={() => handleThemeClick()}
     >

--- a/src/features/utility-bar/ToggleViewportDropdown.tsx
+++ b/src/features/utility-bar/ToggleViewportDropdown.tsx
@@ -31,7 +31,7 @@ export default function (props: ToggleViewportDropdownProps) {
           }
           trigger={
             <button
-              className="btn-subtle btn-icon"
+              className="pk-btn-subtle pk-btn-icon"
               title="Viewport Size [Shift + V]"
               disabled={props.isDoc}
             >
@@ -47,15 +47,17 @@ export default function (props: ToggleViewportDropdownProps) {
                     key={item.size}
                     value={item.size}
                     onClick={() => store.setActiveScreenSize(item.size)}
-                    className="dropdown-item"
+                    className="pk-dropdown-item"
                   >
                     {item.title}
                   </Dropdown.RadioItem>
                 )
               })}
             </Dropdown.RadioGroup>
-            <Dropdown.Separator className="dropdown-separator" />
-            <Dropdown.Item className="dropdown-item">Responsive</Dropdown.Item>
+            <Dropdown.Separator className="pk-dropdown-separator" />
+            <Dropdown.Item className="pk-dropdown-item">
+              Responsive
+            </Dropdown.Item>
           </>
         </Dropdown.Root>
       )}

--- a/src/features/utility-bar/UtilityBar.tsx
+++ b/src/features/utility-bar/UtilityBar.tsx
@@ -18,13 +18,14 @@ export default function (props: UtilityBarProps) {
     <div>
       <header
         className={cx(
-          'flex h-10 justify-between gap-4 border-l border-white bg-gray-100 px-4 transition dark:border-gray-500 dark:bg-gray-700',
+          'pk-flex pk-h-10 pk-justify-between pk-gap-4 pk-border-l pk-border-white pk-bg-gray-100 pk-px-4 pk-transition dark:pk-border-gray-500 dark:pk-bg-gray-700',
           {
-            'border-gray-100 dark:border-gray-700': !store.isNavBarVisible,
+            'pk-border-gray-100 dark:pk-border-gray-700':
+              !store.isNavBarVisible,
           },
         )}
       >
-        <div className="flex items-center gap-2">
+        <div className="pk-flex pk-items-center pk-gap-2">
           {/* Theme Control */}
           <ToggleTheme />
 
@@ -32,7 +33,7 @@ export default function (props: UtilityBarProps) {
           <ToggleViewportDropdown isDoc={props.isDoc} />
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="pk-flex pk-items-center pk-gap-2">
           {/* Settings Control */}
           {props.showSettings && <ToggleSettingsDialog />}
 

--- a/src/features/welcome/Welcome.tsx
+++ b/src/features/welcome/Welcome.tsx
@@ -5,8 +5,8 @@ export default function () {
   const utility = useUtilityBarStore()
 
   return (
-    <div className="max-w-lg px-3 py-10 mx-auto space-y-3">
-      <h1 className="text-xl font-bold">👋 Welcome!</h1>
+    <div className="pk-mx-auto pk-max-w-lg pk-space-y-3 pk-px-3 pk-py-10">
+      <h1 className="pk-text-xl pk-font-bold">👋 Welcome!</h1>
       <p>
         This is a demo of a "decoupled" parts kit. To get started, simply click
         a parts link on the left.
@@ -14,17 +14,17 @@ export default function () {
       <p>
         If you'd like to try this out with your own JSON. Click the{' '}
         <button
-          className="text-blue-600 hover:underline"
+          className="pk-text-blue-600 hover:pk-underline"
           onClick={() => utility.setIsSettingsVisible(true)}
         >
-          <GearIcon className="inline" /> settings button
+          <GearIcon className="pk-inline" /> settings button
         </button>{' '}
         in the top menu bar.
       </p>
       <p>
         Curious what a decoupled parts kit is?{' '}
         <a
-          className="text-blue-600 underline"
+          className="pk-text-blue-600 pk-underline"
           href="https://github.com/vigetlabs/parts-kit"
         >
           📚 Check out the docs

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,6 @@
 
 @layer base {
   body {
-    @apply text-sm text-gray-900;
+    @apply pk-text-sm pk-text-gray-900;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const colors = require('tailwindcss/colors')
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',
-  important: '#parts-kit',
+  prefix: 'pk-',
   theme: {
     screens: {
       sm: '550px',


### PR DESCRIPTION
## About
In a previous PR (#26) I changed the styles of the project to scope as a descendent to `#parts-kit`. This worked pretty well, except I ran into another styling conflict. In the case of our reusable TW plugins such as `button` which can use a similar naming convention to what we used in the Parts Kit, you could theorhetically get a conflict where another projects `.btn` class is conflicting with our Parts Kit `#parts-kit .btn` element. While I could possibly run a scoped reset of styles for that specific element, it might be signaling that a better approach is to use Tailwinds incorporated [`prefix`](https://tailwindcss.com/docs/configuration#prefix) feature which all but ensures that our styles are unique.

To get this working, there was a pretty big initial tradeoff -- every existing TW class needed to be updated to include the `pk-` prefix. This required going through and updating all existing classes as well as ensuring that our plugins were using the new `prefixed` attributes.

---

> Side Note: TW plugins will automatically apply the `pk-` prefix to the name, so you don't technically need to update the class selector in those. That said, the `@apply` styled definitions within the plugins would still need to have the `pk-` prefix. Strange.

---

With this now solved, it's probably worth mention that we'll need to continue to use `pk-` for any future styles we pass into the project. Fortunately, [the TW plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) will automatically apply the prefix while using intellisense for adding new styles, so not too big of a deal.