### PR TITLE
Scope styles to shadow dom

### DIFF
--- a/config/tailwind/buttons.js
+++ b/config/tailwind/buttons.js
@@ -21,24 +21,24 @@ module.exports = plugin(({ addComponents }) => {
 
   const buttons = {
     // Variants
-    '#parts-kit .btn': {
+    '.btn': {
       ...base,
       '@apply bg-blue-500 text-white enabled:hover:bg-blue-600 enabled:active:bg-blue-700 aria-expanded:bg-blue-700':
         {},
     },
-    '#parts-kit .btn-outline': {
+    '.btn-outline': {
       ...base,
       '@apply bg-transparent text-gray-600 border border-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10':
         {},
     },
-    '#parts-kit .btn-subtle': {
+    '.btn-subtle': {
       ...base,
       '@apply bg-transparent text-gray-600 enabled:hover:bg-black/5 enabled:active:bg-black/10 aria-expanded:bg-black/10 dark:text-gray-300 dark:active:text-white dark:enabled:active:bg-black/30 dark:enabled:hover:bg-black/20 dark:aria-expanded:bg-black/30 dark:aria-expanded:text-white':
         {},
     },
 
     // Icon buttons (uses base variants for styling)
-    '#parts-kit .btn-icon': {
+    '.btn-icon': {
       '@apply !gap-0 !p-0 w-6 h-6 !leading-[0] !text-[0]': {},
 
       '& svg': {

--- a/config/tailwind/dropdown.js
+++ b/config/tailwind/dropdown.js
@@ -2,7 +2,7 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = plugin(({ addComponents }) => {
   const dropdown = {
-    '#parts-kit .dropdown': {
+    '.dropdown': {
       '@apply inline-flex flex-col gap-2 p-2 bg-white border border-gray-300 shadow min-w-[200px] max-w-[250px] rounded-xl z-50 dark:bg-gray-800 dark:border-gray-500 transition-colors':
         {},
 
@@ -21,7 +21,7 @@ module.exports = plugin(({ addComponents }) => {
       },
     },
 
-    '#parts-kit .dropdown-item': {
+    '.dropdown-item': {
       '@apply cursor-pointer flex items-center px-3 min-h-8 hover:bg-black/5 hover:outline-none active:bg-black/10 w-full gap-2 justify-between rounded-md aria-checked:bg-blue-500 aria-checked:text-white aria-checked:hover:bg-blue-400 aria-checked:active:bg-blue-500 dark:text-white dark:hover:bg-black/30 dark:active:bg-black/40 aria-checked:dark:hover:bg-blue-400 aria-checked:dark:active:bg-blue-500 transition-colors':
         {},
 
@@ -30,11 +30,11 @@ module.exports = plugin(({ addComponents }) => {
       },
     },
 
-    '#parts-kit .dropdown-separator': {
+    '.dropdown-separator': {
       '@apply h-px mx-3 bg-gray-300 dark:bg-gray-500 transition-colors': {},
     },
 
-    '#parts-kit .dropdown-arrow': {
+    '.dropdown-arrow': {
       '@apply fill-gray-300 dark:fill-gray-400 transition-colors': {},
     },
   }

--- a/config/tailwind/icons.js
+++ b/config/tailwind/icons.js
@@ -2,10 +2,10 @@ const plugin = require('tailwindcss/plugin')
 
 module.exports = plugin(({ addComponents }) => {
   const icons = {
-    '#parts-kit .icon': {
+    '.icon': {
       '@apply h-4 w-4': {},
     },
-    '#parts-kit .icon-lg': {
+    '.icon-lg': {
       '@apply h-5 w-5': {},
     },
   }

--- a/index.html
+++ b/index.html
@@ -4,14 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
-
     <title>Vite + Preact + TS</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,10 @@
         "tailwindcss": "^3.3.3",
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
-        "vite-plugin-css-injected-by-js": "^3.3.0",
         "vitest": "^0.34.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8617,15 +8619,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-plugin-css-injected-by-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.3.0.tgz",
-      "integrity": "sha512-xG+jyHNCmUqi/TXp6q88wTJGeAOrNLSyUUTp4qEQ9QZLGcHWQQsCsSSKa59rPMQr8sOzfzmWDd8enGqfH/dBew==",
-      "dev": true,
-      "peerDependencies": {
-        "vite": ">2.0.0-0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "tailwindcss": "^3.3.3",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
-    "vite-plugin-css-injected-by-js": "^3.3.0",
     "vitest": "^0.34.2"
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import { useSettingsStore } from './features/settings/store.ts'
 import {
   ScreenSize,
   screenSizeMap,
+  useThemeStore,
   useUtilityBarStore,
 } from './features/utility-bar/store.ts'
 import Welcome from './features/welcome/Welcome.tsx'
@@ -34,6 +35,7 @@ export interface Config {
 export function App(props: AppProps) {
   const settings = useSettingsStore()
   const utilityStore = useUtilityBarStore()
+  const themeStore = useThemeStore()
 
   const [config, setConfig] = useState<Config>({ nav: [] })
   const hasConfigUrl = !!props.configUrl
@@ -117,7 +119,13 @@ export function App(props: AppProps) {
   KeyboardShortcuts()
 
   return (
-    <div className="font-sans">
+    <div className={cx(
+      'font-sans',
+      {
+        'light': themeStore.mode === 'light',
+        'dark': themeStore.mode === 'dark',
+      }
+    )}>
       <div
         className={cx(
           'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all duration-500',

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'preact/hooks'
-import './app.css'
 import cx from 'classnames'
 import { Nav } from './features/nav/Nav.tsx'
 import { NavItemInterface } from './features/nav/Nav.tsx'

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -117,7 +117,7 @@ export function App(props: AppProps) {
   KeyboardShortcuts()
 
   return (
-    <div id="parts-kit">
+    <div className="font-sans">
       <div
         className={cx(
           'grid h-screen grid-cols-[250px,1fr] bg-gray-100 transition-all duration-500',

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'preact/hooks'
-import { useUtilityBarStore } from '../features/utility-bar/store'
-import { handleThemeClick } from '../features/utility-bar/ToggleTheme'
+import { useThemeStore, useUtilityBarStore } from '../features/utility-bar/store'
 
 export default function () {
   const utilityStore = useUtilityBarStore()
+  const themeStore = useThemeStore()
 
   // handles different keyboard shortcuts
   const keydownHandler = (e: KeyboardEvent) => {
@@ -38,7 +38,7 @@ export default function () {
       case 'T':
         if (e.shiftKey) {
           e.preventDefault()
-          handleThemeClick()
+          themeStore.toggleMode()
         }
         return
 
@@ -65,5 +65,6 @@ export default function () {
     utilityStore.isNavBarVisible,
     utilityStore.isViewportOpen,
     utilityStore.isSettingsOpen,
+    themeStore.mode,
   ])
 }

--- a/src/custom-elements/parts-kit.tsx
+++ b/src/custom-elements/parts-kit.tsx
@@ -7,11 +7,24 @@ export default class PartsKit extends HTMLElement {
 
   private shadow:ShadowRoot
 
+  /**
+   * Using constructable stylesheets.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM?ref=blog.jonas.liljegren.org#constructable_stylesheets
+   *
+   * In the future, we could make this variable globally shared across all web components that want to load our
+   * Tailwind based stylesheet.
+   *
+   * This doesn't work in Safari 16.3 and less. 16.4 was Released 2023-03-27
+   */
+  private styleSheet = new CSSStyleSheet()
+
   constructor() {
     // Always call super first in constructor
     super()
 
     this.shadow = this.attachShadow({mode: 'open'})
+    this.shadow.adoptedStyleSheets = [this.styleSheet]
 
     // TODO ensure this works
 
@@ -42,11 +55,11 @@ export default class PartsKit extends HTMLElement {
           return;
         }
 
-        this.setStyles(newCssString.default)
+        this.styleSheet.replaceSync(newCssString.default)
       })
     }
 
-    this.setStyles(cssString)
+    this.styleSheet.replaceSync(cssString)
 
     render(<App configUrl={configUrl} />, this.shadow)
   }
@@ -55,10 +68,4 @@ export default class PartsKit extends HTMLElement {
     render(null, this)
   }
 
-  private setStyles(cssString:string) {
-    const styleElement = this.querySelector('#css') || document.createElement('style')
-    styleElement.textContent = ''
-    styleElement.appendChild(document.createTextNode(cssString))
-    this.shadow.appendChild(styleElement)
-  }
 }

--- a/src/custom-elements/parts-kit.tsx
+++ b/src/custom-elements/parts-kit.tsx
@@ -45,7 +45,34 @@ export default class PartsKit extends HTMLElement {
   connectedCallback() {
     const configUrl = this.getAttribute('config-url')
 
-    // TODO, font styles
+    this.setUpStyles()
+
+    render(<App configUrl={configUrl} />, this.shadow)
+  }
+
+  disconnectedCallback() {
+    render(null, this)
+  }
+
+  private setUpStyles(): void {
+    const googleFontsLink = document.createElement('link')
+    googleFontsLink.href = 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap'
+    googleFontsLink.rel = 'stylesheet'
+
+    document.head.appendChild(googleFontsLink)
+
+    // Since our main stylesheet is scoped to the web component, we want to ensure that the body tag doesn't have its default padding & margins.
+    const bodyStyles = document.createElement('style')
+    bodyStyles.appendChild(document.createTextNode(`
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    `))
+    document.head.appendChild(bodyStyles)
+
+    // Attach styles to this custom element
+    this.styleSheet.replaceSync(cssString)
 
     // Respond to HMR of our styles. This is tree shaken when building for prod
     // https://vitejs.dev/guide/api-hmr#hot-accept-deps-cb
@@ -58,14 +85,5 @@ export default class PartsKit extends HTMLElement {
         this.styleSheet.replaceSync(newCssString.default)
       })
     }
-
-    this.styleSheet.replaceSync(cssString)
-
-    render(<App configUrl={configUrl} />, this.shadow)
   }
-
-  disconnectedCallback() {
-    render(null, this)
-  }
-
 }

--- a/src/features/utility-bar/ToggleTheme.tsx
+++ b/src/features/utility-bar/ToggleTheme.tsx
@@ -1,21 +1,14 @@
 import { BlendingModeIcon } from '@radix-ui/react-icons'
-
-export function handleThemeClick() {
-  if (localStorage.theme && localStorage.theme == 'dark') {
-    localStorage.theme = 'light'
-    document.documentElement.classList.remove('dark')
-  } else {
-    localStorage.theme = 'dark'
-    document.documentElement.classList.add('dark')
-  }
-}
+import { useThemeStore } from './store'
 
 export default function () {
+  const themeStore = useThemeStore()
+
   return (
     <button
       className="btn-subtle btn-icon"
       title="Toggle Theme [Shift + T]"
-      onClick={() => handleThemeClick()}
+      onClick={() => themeStore.toggleMode()}
     >
       <BlendingModeIcon />
     </button>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,3 @@
-// TODO figure out how to isolate CSS from rest of project
-import './index.css'
 import PartsKit from './custom-elements/parts-kit'
 
 customElements.define('parts-kit', PartsKit)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,6 @@ const colors = require('tailwindcss/colors')
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',
-  important: '#parts-kit',
   theme: {
     screens: {
       sm: '550px',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,11 @@
 import { mergeConfig, UserConfig } from 'vite'
 import { defineConfig } from 'vitest/config'
 import preact from '@preact/preset-vite'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 
 /** Config shared by all of our build processes. Used with `mergeConfig` */
 export const sharedConfig: UserConfig = defineConfig({
   plugins: [
     preact(),
-    cssInjectedByJsPlugin({
-      injectCodeFunction: (cssCode) => {
-        try {
-          // Only inject parts kit styles if the <parts-kit> custom element is present
-          if (typeof document != 'undefined' && document.querySelector('parts-kit')) {
-            const elementStyle = document.createElement('style')
-            elementStyle.appendChild(document.createTextNode(cssCode))
-            document.head.appendChild(elementStyle)
-          }
-        } catch (e) {
-          console.error('vite-plugin-css-injected-by-js', e)
-        }
-      },
-    }),
   ],
   test: {
     globals: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,30 @@
 import { mergeConfig, UserConfig } from 'vite'
-import { defineConfig} from 'vitest/config'
+import { defineConfig } from 'vitest/config'
 import preact from '@preact/preset-vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
-
 
 /** Config shared by all of our build processes. Used with `mergeConfig` */
 export const sharedConfig: UserConfig = defineConfig({
   plugins: [
     preact(),
-    cssInjectedByJsPlugin(),
+    cssInjectedByJsPlugin({
+      injectCodeFunction: (cssCode) => {
+        try {
+          // Only inject parts kit styles if the <parts-kit> custom element is present
+          if (typeof document != 'undefined' && document.querySelector('parts-kit')) {
+            const elementStyle = document.createElement('style')
+            elementStyle.appendChild(document.createTextNode(cssCode))
+            document.head.appendChild(elementStyle)
+          }
+        } catch (e) {
+          console.error('vite-plugin-css-injected-by-js', e)
+        }
+      },
+    }),
   ],
   test: {
     globals: true,
-  }
+  },
 })
 
 export default mergeConfig(sharedConfig, {


### PR DESCRIPTION
Everything below doesn't apply anymore. 

This PR ended up moving everything to the Shadow DOM so that all of our styles are protected from outside influence and don't influence pages either.

----

This is a little hard to fully test with our CDN deployment, but I'll outline the steps I took to test and if anyone wants to double check that process, they're more than welcome to.

Or we could YOLO a deploy and just see if it works 😆 

**❓ Removing `important: '#parts-kit',` from TW config?**

I thought about removing this, since we no longer need to worry about the PK styles bleeding into our component styles.

However, it might still offer some protection of the main site's styles bleeding in to the `<parts-kit>` custom elements markup. 

I think best case scenario, we don't want to include any other styles or scripts on the page that includes the JS file and `<parts-kit>` custom element (this is what I'm doing with the Craft setup). But that might not always be easy to do depending on the tech stack.

<img width=300 src=https://github.com/vigetlabs/parts-kit/assets/2145998/c5a38803-7582-453f-ba72-33f13a1e5a8a>


### Testing Steps


**Build:**
```
npm run build
```

This puts our JS and html into the `dist` folder. The CSS string is part of the JS file. The vite config change means that the `<style>` tag should only be created when the `<parts-kit>` custom element is on the page.

I created a second HTML file that doesn't contain the `<parts-kit>` custom element.

![image](https://github.com/vigetlabs/parts-kit/assets/2145998/c62dcd5f-e8e0-4007-9d49-090e89497f8b)


**Serve Locally**

Using [http-server](https://github.com/http-party/http-server) I served the contents of the `dist` directory.

```
npx http-server ./dist
```

index.html loads, the `<style>` tag is injected into the page.

![image](https://github.com/vigetlabs/parts-kit/assets/2145998/ccf9a2b4-ba94-4ee6-bfaa-b766d8dd5a4a)

index-no-parts-kit.html loads, but the tailwind `<style>` tag isn't present in the head.

![image](https://github.com/vigetlabs/parts-kit/assets/2145998/0a640e55-f9a5-4d37-9d3c-7a0b29d17d81)
