### PR TITLE
[#33] Fix Radix UI portal bugs.

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,6 +1,7 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { JSX } from 'preact/jsx-runtime'
 import { Cross1Icon } from '@radix-ui/react-icons'
+import { partsKitRoot } from '../utilities/customElements'
 
 interface RootProps {
   trigger: JSX.Element
@@ -17,7 +18,7 @@ const Root = (props: RootProps) => {
         {props.trigger && props.trigger}
       </DialogPrimitive.Trigger>
 
-      <DialogPrimitive.Portal container={document.getElementById('parts-kit')}>
+      <DialogPrimitive.Portal container={partsKitRoot()}>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-gray-900/60 backdrop-blur-[2px] data-[state=open]:animate-dialog-overlay-show" />
         <DialogPrimitive.Content className="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-md translate-x-[-50%] translate-y-[-50%] rounded-xl border border-gray-300 bg-white px-6 py-8 shadow-lg transition-colors focus:outline-none data-[state=open]:animate-dialog-content-show dark:border-gray-500 dark:bg-gray-800 dark:text-white">
           {props.closeable && (

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { JSX } from 'preact/jsx-runtime'
+import { partsKitRoot } from '../utilities/customElements'
 
 interface RootProps {
   trigger: JSX.Element
@@ -18,7 +19,7 @@ const Root = (props: RootProps) => {
         {props.trigger && props.trigger}
       </DropdownMenu.Trigger>
 
-      <DropdownMenu.Portal container={document.getElementById('parts-kit')}>
+      <DropdownMenu.Portal container={partsKitRoot()}>
         <DropdownMenu.Content
           sideOffset={5}
           align={props.align || 'start'}

--- a/src/custom-elements/parts-kit.tsx
+++ b/src/custom-elements/parts-kit.tsx
@@ -11,6 +11,8 @@ let hasSetUpStyles = false
 export default class PartsKit extends HTMLElement {
   private shadow: ShadowRoot
 
+  static readonly elementName = 'parts-kit'
+
   /**
    * Using constructable stylesheets.
    *

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,3 @@
 import PartsKit from './custom-elements/parts-kit'
 
-customElements.define('parts-kit', PartsKit)
+customElements.define(PartsKit.elementName, PartsKit)

--- a/src/utilities/customElements.ts
+++ b/src/utilities/customElements.ts
@@ -1,0 +1,7 @@
+import PartsKit from '../custom-elements/parts-kit'
+
+/**
+ * Finds the first child node in the parts-kit custom element.
+ */
+export const partsKitRoot = () =>
+  document.querySelector(PartsKit.elementName)?.shadowRoot?.firstChild


### PR DESCRIPTION
- #33

I missed that our Radix components were pointed at the `#parts-kit` ID that I removed. 

This fixes our dropdowns and dialogs.